### PR TITLE
Issue when operational overview report returns `list` instead of `dict` as fallback value for `rules_data` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed invalid `next_token` handling
 - Fixed issue with double creation of indexes for `SREResources` and `SREResourceExceptions` collections
+- Fixed issue when operational overview report returns `list` instead of `dict` as fallback value for `rules_data` field
 
 ### Changed
 - Changed the `JobType` enum to include `STANDARD`, `SCHEDULED` and `MANUAL`


### PR DESCRIPTION
# Additional fixes

## `assert` statements

1. **Can be disabled**: Python's `-O` (optimize) flag removes all `assert` statements at runtime, making them unreliable in production
2. **Poor error messages**: `AssertionError` provides minimal context for debugging
3. **Wrong tool for the job**: `assert` is meant for debugging, not runtime validation
4. **Hard to handle**: Business logic errors should raise appropriate exceptions that can be caught and logged