### PR TITLE
Operational deprecation previous period findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.17.0] - 2026-02-25
 
 ### Added
+- Added number of findings from the previous reporting period (`previous_period_findings`) for rules that are now deprecated in the OPERATIONAL_DEPRECATION report
 - Added Event-Driven (ED) jobs support for AMI installation
 - Added `STANDARD`, `SCHEDULED` to the `JobType` enum
 - Added recipient validation emails for reports based on the associated Tenant or Customer

--- a/src/lambdas/metrics_updater/processors/metrics_collector.py
+++ b/src/lambdas/metrics_updater/processors/metrics_collector.py
@@ -821,7 +821,7 @@ class MetricsCollector(BaseProcessor):
                     _, collection_prev = exceptions.filter_exception_resources(
                         previous_collection, cloud, ctx.metadata, tenant.project
                     )
-                    rule_resources_prev = rule_resources_dict(
+                    rule_resources_prev = self._get_rule_resources(
                         collection_prev, cloud, ctx.metadata, tenant.project
                     )
                     start_d = (

--- a/src/lambdas/metrics_updater/processors/metrics_collector.py
+++ b/src/lambdas/metrics_updater/processors/metrics_collector.py
@@ -3,6 +3,8 @@ import heapq
 import statistics
 from datetime import date, datetime
 from itertools import chain
+
+from dateutil.relativedelta import relativedelta
 from typing import (
     TYPE_CHECKING,
     Generator,
@@ -808,6 +810,41 @@ class MetricsCollector(BaseProcessor):
             deprecated_in_scope = tuple(
                 rule for rule in deprecated if rule.id in deprecated_loc
             )
+
+            # For deprecation report: count findings from previous period for
+            # rules that are deprecated in the current period (first report only).
+            previous_period_findings: dict[str, int] | None = None
+            if typ is ReportType.OPERATIONAL_DEPRECATION:
+                previous_end = end + relativedelta(weeks=-1)
+                previous_collection = scp.get_for_tenant(tenant, previous_end)
+                if previous_collection is not None:
+                    _, collection_prev = exceptions.filter_exception_resources(
+                        previous_collection, cloud, ctx.metadata, tenant.project
+                    )
+                    rule_resources_prev = rule_resources_dict(
+                        collection_prev, cloud, ctx.metadata, tenant.project
+                    )
+                    start_d = (
+                        start.date()
+                        if isinstance(start, datetime)
+                        else start
+                    )
+                    end_d = (
+                        end.date() if isinstance(end, datetime) else end
+                    )
+                    previous_period_findings = {}
+                    for rule in rule_resources:
+                        rm = ctx.metadata.rule(rule)
+                        if not rm.deprecation_category():
+                            continue
+                        if not rm.deprecation.is_deprecated or not isinstance(
+                            rm.deprecation.date, date
+                        ):
+                            continue
+                        if start_d <= rm.deprecation.date <= end_d:
+                            previous_period_findings[rule] = len(
+                                rule_resources_prev.get(rule, set())
+                            )
             
             meta = TenantReportMetadata(
                 licenses=licenses,
@@ -846,6 +883,7 @@ class MetricsCollector(BaseProcessor):
                 end=end,
                 meta=collection.meta,
                 cloud=cloud,
+                previous_period_findings=previous_period_findings,
             )
             if not isinstance(data, dict):
                 # TODO: somehow move this info to visitors abstraction

--- a/src/services/reports.py
+++ b/src/services/reports.py
@@ -444,6 +444,12 @@ class DeprecationReportGenerator(ReportVisitor[Generator[dict, None, None]]):
         meta: dict[str, RuleMeta],
         **kwargs,
     ) -> Generator[dict, None, None]:
+        start = kwargs.get('start')
+        end = kwargs.get('end')
+        previous_period_findings: dict[str, int] | None = kwargs.get(
+            'previous_period_findings'
+        )
+
         for rule in rule_resources:
             if self.scope is not None and rule not in self.scope:
                 continue
@@ -457,7 +463,7 @@ class DeprecationReportGenerator(ReportVisitor[Generator[dict, None, None]]):
                     r.accept(self._view, report_fields=rm.report_fields)
                 )
 
-            yield {
+            result = {
                 'category': category,
                 'deprecation_date': rm.deprecation.date.isoformat()
                 if isinstance(rm.deprecation.date, date)
@@ -468,6 +474,25 @@ class DeprecationReportGenerator(ReportVisitor[Generator[dict, None, None]]):
                 'policy': rule,
                 'resources': by_region,
             }
+
+            # Add previous period findings count only in the first report
+            # after the rule is deprecated (deprecation date in current period).
+            if (
+                rm.deprecation.is_deprecated
+                and isinstance(rm.deprecation.date, date)
+                and start is not None
+                and end is not None
+                and previous_period_findings is not None
+                and rule in previous_period_findings
+            ):
+                start_d = start.date() if isinstance(start, datetime) else start
+                end_d = end.date() if isinstance(end, datetime) else end
+                if start_d <= rm.deprecation.date <= end_d:
+                    result['previous_period_findings'] = previous_period_findings[
+                        rule
+                    ]
+
+            yield result
 
 
 class FinopsReportGenerator(ReportVisitor[Generator[dict, None, None]]):

--- a/tests/tests_services/test_reports.py
+++ b/tests/tests_services/test_reports.py
@@ -1,23 +1,31 @@
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Callable
-
 import msgspec
 import pytest
 
-from helpers.constants import Cloud, JobType
+from helpers.constants import (
+    Cloud,
+    JobType,
+    ReportType,
+    RemediationComplexity,
+    Severity,
+)
 from helpers.reports import adjust_resource_type
 from helpers.time_helper import utc_datetime
 from models.job import Job
-from services.metadata import Metadata
+from services.metadata import Deprecation, Metadata, RuleMetadata
 from services.reports import (
+    DeprecationReportGenerator,
     JobMetricsDataSource,
+    Report,
     ShardsCollectionDataSource,
     add_diff,
 )
+from services.resources import AZUREResource, MaestroReportResourceView
 from services.sharding import AWSRegionDistributor, ShardPart, ShardsCollection
 
-from ..commons import AWS_ACCOUNT_ID
+from ..commons import AWS_ACCOUNT_ID, dicts_equal, mock_date_today
 
 
 @pytest.fixture
@@ -308,3 +316,173 @@ def test_add_diff():
             'HIPAA': {'value': 0.1},
         },
     }
+
+
+class TestDeprecationReportGenerator:
+    """Tests for DeprecationReportGenerator and previous_period_findings."""
+
+    @pytest.fixture
+    def deprecation_rule_metadata(self):
+        """Rule metadata for a rule deprecated in report period (2025-07-17)."""
+        return RuleMetadata(
+            source='testing',
+            category='Deprecation > Runtime version',
+            service_section='Compute',
+            service='Defender Pricing',
+            article='',
+            impact='',
+            remediation='Remediation text here',
+            severity=Severity.UNKNOWN,
+            report_fields=(),
+            periodic=False,
+            standard={},
+            mitre={},
+            waf={},
+            remediation_complexity=RemediationComplexity.UNKNOWN,
+            deprecation=Deprecation(
+                date=date(2025, 7, 17), link='https://example.com'
+            ),
+            cloud='AZURE',
+            events=None,
+        )
+
+    @pytest.fixture
+    def deprecation_metadata(self, deprecation_rule_metadata):
+        """Metadata with one deprecation rule."""
+        return Metadata(
+            rules={
+                'ecc-azure-096-cis_sec_defender_azure_sql': deprecation_rule_metadata,
+            },
+        )
+
+    @pytest.fixture
+    def deprecation_rule_resources(self):
+        """One Azure resource for the deprecation rule."""
+        resource = AZUREResource(
+            id='/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/SqlServers',
+            name='SqlServers',
+            location='global',
+            resource_type='azure.defender-pricing',
+            sync_date=1729502334.624495,
+            data={},
+        )
+        return {'ecc-azure-096-cis_sec_defender_azure_sql': {resource}}
+
+    def test_deprecation_report_with_previous_period_findings(
+        self,
+        deprecation_metadata,
+        deprecation_rule_resources,
+        load_expected,
+    ):
+        """Generator adds previous_period_findings when rule is just deprecated."""
+        with mock_date_today('datetime.date', date(2025, 7, 18)):
+            report = Report.derive_report(ReportType.OPERATIONAL_DEPRECATION)
+            generator = DeprecationReportGenerator(
+                metadata=deprecation_metadata,
+                view=MaestroReportResourceView(),
+                scope=None,
+            )
+            start = datetime(2025, 7, 17)
+            end = datetime(2025, 7, 18)
+            result = tuple(
+                report.accept(
+                    generator,
+                    rule_resources=deprecation_rule_resources,
+                    meta={},
+                    start=start,
+                    end=end,
+                    previous_period_findings={
+                        'ecc-azure-096-cis_sec_defender_azure_sql': 3,
+                    },
+                )
+            )
+            expected = [
+                {
+                    "category": "Runtime version",
+                    "deprecation_date": "2025-07-17",
+                    "is_deprecated": True,
+                    "deprecation_severity": "High",
+                    "deprecation_link": "https://example.com",
+                    "policy": "ecc-azure-096-cis_sec_defender_azure_sql",
+                    "resources": {
+                    "global": [
+                        {
+                        "id": "/subscriptions/3d615fa8-05c6-47ea-990d-9d162testing/providers/Microsoft.Security/pricings/SqlServers",
+                        "name": "SqlServers",
+                        "sre:date": 1729502334.624495
+                        }
+                    ]
+                    },
+                    "previous_period_findings": 3
+                }
+            ]
+            assert len(result) == len(expected)
+            assert dicts_equal(list(result), expected)
+
+    def test_deprecation_report_without_previous_period_findings(
+        self,
+        deprecation_metadata,
+        deprecation_rule_resources,
+        load_expected,
+    ):
+        """Generator does not add previous_period_findings when not provided."""
+        with mock_date_today('datetime.date', date(2025, 7, 18)):
+            report = Report.derive_report(ReportType.OPERATIONAL_DEPRECATION)
+            generator = DeprecationReportGenerator(
+                metadata=deprecation_metadata,
+                view=MaestroReportResourceView(),
+                scope=None,
+            )
+            start = datetime(2025, 7, 17)
+            end = datetime(2025, 7, 18)
+            result = tuple(
+                report.accept(
+                    generator,
+                    rule_resources=deprecation_rule_resources,
+                    meta={},
+                    start=start,
+                    end=end,
+                    previous_period_findings=None,
+                )
+            )
+            # Same structure as metrics/azure_operational_deprecations data item,
+            # but without previous_period_findings
+            expected_item = load_expected(
+                'metrics/azure_operational_deprecations'
+            )['data'][0]
+            assert len(result) == 1
+            assert 'previous_period_findings' not in result[0]
+            assert result[0]['policy'] == expected_item['policy']
+            assert result[0]['category'] == expected_item['category']
+            assert result[0]['resources'] == expected_item['resources']
+
+    def test_deprecation_report_deprecation_date_outside_period(
+        self,
+        deprecation_metadata,
+        deprecation_rule_resources,
+    ):
+        """Generator does not add previous_period_findings when deprecation date is outside report period."""
+        with mock_date_today('datetime.date', date(2025, 7, 18)):
+            report = Report.derive_report(ReportType.OPERATIONAL_DEPRECATION)
+            generator = DeprecationReportGenerator(
+                metadata=deprecation_metadata,
+                view=MaestroReportResourceView(),
+                scope=None,
+            )
+            # Period where 2025-07-17 is NOT included (e.g. previous week)
+            start = datetime(2025, 7, 10)
+            end = datetime(2025, 7, 16)
+            result = tuple(
+                report.accept(
+                    generator,
+                    rule_resources=deprecation_rule_resources,
+                    meta={},
+                    start=start,
+                    end=end,
+                    previous_period_findings={
+                        'ecc-azure-096-cis_sec_defender_azure_sql': 3,
+                    },
+                )
+            )
+            assert len(result) == 1
+            assert 'previous_period_findings' not in result[0]


### PR DESCRIPTION
## What was done

Operational deprecation report (`OPERATIONAL_DEPRECATION`) now shows **how many findings** there were in the **previous reporting period** for rules that have **just become deprecated**. This is shown only in the **first report** after the rule is deprecated.

## Behaviour

- **When** the rule’s deprecation date falls within the current report period (`from`–`to`) **and** the rule is deprecated → field `previous_period_findings` is added.
- **When** the rule was deprecated earlier or is not yet deprecated → `previous_period_findings` is **not** added.
- **Value** = total number of resources (findings) for that rule in the previous reporting period (previous week).
