### PR TITLE
feat: Improved sre-init initialization flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added Python 3.14 support (`requires-python = ">=3.14,<4"`)
+- Improved sre-init initialization flow:
+  - Fixed artifact resolution in get_latest_local_release during user addition.
+  - Improved local release artifact detection to ensure the correct SRE artifacts are selected when installing CLI tools for a user.
+  - Added support for explicitly specifying the Python interpreter used during CLI installation.
+  - This change prepares the installation flow for future Modular CLI requirements, where Modular CLI will support only Python 3.14 and later versions.
+  - Added Python version validation before Modular CLI installation/update.
+  - Added support for reading Modular CLI Python requirements from release metadata.
+  - Added a doctor / check command to validate local environment readiness.
+  - Added user-facing warnings/errors for Python compatibility changes.
+  - Avoided changing or relying on the system default /usr/bin/python3.
+  - Resolved the latest local release only once during CLI installation to avoid inconsistent artifact resolution during user initialization.
 
 ### Fixed
 - [12128] Fixed `sre rule update` returning `No rule sources were found` response when the requested rule source is already `SYNCING`

--- a/deployment/aws-ami/debian-minikube/ami-initialize.sh
+++ b/deployment/aws-ami/debian-minikube/ami-initialize.sh
@@ -398,17 +398,6 @@ helm repo update syndicate
 
 helm install "$HELM_RELEASE_NAME" syndicate/rule-engine --version $RULE_ENGINE_RELEASE $(build_helm_values)
 helm install "$DEFECTDOJO_HELM_RELEASE_NAME" syndicate/defectdojo
-
-# Temporary workaround: Docker 29+ sets RLIM_INFINITY for containerd pods which crashes uWSGI during prefork.
-# Patch defectdojo deployments to wrap entrypoints with `ulimit -n 65536`.
-# TODO: remove once defectdojo helm chart embeds ulimit in container commands and a new chart version is released.
-for deploy in defectdojo-uwsgi defectdojo-celeryworker defectdojo-celerybeat; do
-  cmd=\$(kubectl get deployment \$deploy -o jsonpath='{.spec.template.spec.containers[0].command}' 2>/dev/null || true)
-  if [ -n "\$cmd" ] && echo "\$cmd" | grep -qv 'ulimit'; then
-    entrypoint=\$(kubectl get deployment \$deploy -o jsonpath='{.spec.template.spec.containers[0].command[-1]}')
-    kubectl patch deployment \$deploy --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command\",\"value\":[\"/bin/sh\",\"-c\",\"ulimit -n 65536 && exec \$entrypoint\"]}]"
-  fi
-done
 EOF
 
 if [ -z "$lm_response" ]; then

--- a/deployment/aws-ami/debian-minikube/release.json
+++ b/deployment/aws-ami/debian-minikube/release.json
@@ -9,26 +9,3 @@
     }
   }
 }
-
-// min ver
-{
-  "version": "5.21.0",
-  "components": {
-    "modular_cli": {
-      "python_min_version": "3.14",
-      "breaking_change": false
-    }
-  }
-}
-
-{
-  "version": "5.51.0",
-  "components": {
-    "modular_cli": {
-      "python_min_version": "3.14",
-      "compatibility_mode": "warn",
-      "breaking_change": false,
-      "message": "No compatibility-breaking changes in this release."
-    }
-  }
-}

--- a/deployment/aws-ami/debian-minikube/release.json
+++ b/deployment/aws-ami/debian-minikube/release.json
@@ -1,0 +1,34 @@
+{
+  "version": "5.20.0",
+  "components": {
+    "modular_cli": {
+      "python_min_version": "3.14",
+      "compatibility_mode": "error",
+      "breaking_change": true,
+      "message": "Modular CLI requires Python 3.14 or later starting from this release."
+    }
+  }
+}
+
+// min ver
+{
+  "version": "5.21.0",
+  "components": {
+    "modular_cli": {
+      "python_min_version": "3.14",
+      "breaking_change": false
+    }
+  }
+}
+
+{
+  "version": "5.51.0",
+  "components": {
+    "modular_cli": {
+      "python_min_version": "3.14",
+      "compatibility_mode": "warn",
+      "breaking_change": false,
+      "message": "No compatibility-breaking changes in this release."
+    }
+  }
+}

--- a/deployment/aws-ami/debian-minikube/sre-init.sh
+++ b/deployment/aws-ami/debian-minikube/sre-init.sh
@@ -475,7 +475,7 @@ Interpreter: $python_bin
 
 To avoid installation or update failures, install Python $required_version+ and explicitly pass it to sre-init:
 
-  SRE_PYTHON_BIN=/usr/local/bin/python${required_version} sre-init init --user <username>
+  SRE_PYTHON_BIN=/usr/local/bin/python${required_version} sre-init ...
 
 Do not replace the system default /usr/bin/python3, as it may break OS-level tools.
 EOF
@@ -726,7 +726,7 @@ initialize_system() {
   release_path="$SRE_RELEASES_PATH/$latest_local_release"
 
   echo "Installing obfuscation manager"
-  pipx_install_artifact "$python_bin" "$release_path/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" "sre-obfuscator" || die_with_support "Failed to install obfuscation manager"
+  pipx_install_artifact "$python_bin" "sre-obfuscator" "$release_path/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" || die_with_support "Failed to install obfuscation manager"
 
   echo "Installing modular-cli"
   MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT  pipx_install_artifact "$python_bin" "modular-cli" "$release_path/$MODULAR_CLI_ARTIFACT_NAME" || die_with_support "Failed to install modular-cli"
@@ -1317,12 +1317,12 @@ cmd_update() {
   cli_python_bin="$(check_modular_cli_python_compatibility "$latest_tag")"
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$OBFUSCATOR_ARTIFACT_NAME" ]; then
     echo "Upgrading obfuscation manager"
-    pipx_install_artifact "$cli_python_bin" "$SRE_RELEASES_PATH/$latest_tag/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" "sre-obfuscator" >/dev/null
+    pipx_install_artifact "$cli_python_bin" "sre-obfuscator" "$SRE_RELEASES_PATH/$latest_tag/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" >/dev/null
   fi
 
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$MODULAR_CLI_ARTIFACT_NAME" ]; then
     echo "Upgrading modular CLI"
-    MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx_install_artifact "$cli_python_bin" "$SRE_RELEASES_PATH/$latest_tag/${MODULAR_CLI_ARTIFACT_NAME}" "modular-cli" >/dev/null
+    MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx_install_artifact "$cli_python_bin" "modular-cli" "$SRE_RELEASES_PATH/$latest_tag/${MODULAR_CLI_ARTIFACT_NAME}" >/dev/null
   fi
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$SRE_INIT_ARTIFACT_NAME" ]; then
     echo "Updating sre-init"

--- a/deployment/aws-ami/debian-minikube/sre-init.sh
+++ b/deployment/aws-ami/debian-minikube/sre-init.sh
@@ -1287,7 +1287,7 @@ cmd_update() {
     # TODO: check artifacts from previous release? and copy if totally the same
     pull_artifacts "$release_data"
   fi
-  if [ -f "$SRE_RELEASES_PATH/$latest_tag/$MODULAR_CLI_ARTIFACT_NAME" ]; then
+  if [[ -f "$SRE_RELEASES_PATH/$latest_tag/$MODULAR_CLI_ARTIFACT_NAME" || -f "$SRE_RELEASES_PATH/$latest_tag/$OBFUSCATOR_ARTIFACT_NAME" ]]; then
     check_modular_cli_python_compatibility "$latest_tag" >/dev/null
   fi
   if [ "$do_backup" -eq 1 ]; then

--- a/deployment/aws-ami/debian-minikube/sre-init.sh
+++ b/deployment/aws-ami/debian-minikube/sre-init.sh
@@ -48,6 +48,8 @@ Available Commands:
   secrets  Allow to retrieve some secrets generated on startup. They are located inside k8s cluster
   update   Update the installation
   version  Print versions information
+  doctor   Check local environment and CLI compatibility
+  check    Alias for doctor
 EOF
 }
 
@@ -64,6 +66,15 @@ Usage:
 Examples:
   $PROGRAM $COMMAND --system
   $PROGRAM $COMMAND --user example --public-ssh-key "ssh-rsa AAA..."
+
+Environment variables:
+
+  SRE_PYTHON_BIN
+      Optional Python interpreter used by pipx to install SRE CLI applications.
+      Example: SRE_PYTHON_BIN=python3.14 ./sre-init.sh init --user <username> ...
+
+      If not provided, the script uses system python3.
+      The script does not modify /usr/bin/python3.
 
 Options:
   -h, --help        Show this message and exit
@@ -264,6 +275,28 @@ Options
 EOF
 }
 
+cmd_doctor_usage() {
+  cat <<EOF
+Usage:
+  $PROGRAM doctor [OPTIONS]
+  $PROGRAM check [OPTIONS]
+
+Checks local environment and SRE CLI installation compatibility.
+
+Options:
+  --release <version>    Check compatibility against a specific local release
+  -h, --help             Show this help message
+
+Environment variables:
+  SRE_PYTHON_BIN         Optional Python interpreter used by pipx to install SRE CLI applications.
+                         Example:
+                           SRE_PYTHON_BIN=/usr/local/bin/python3.14 $PROGRAM doctor
+
+  SRE_PYTHON_COMPAT_MODE Compatibility behavior when Python requirement is not satisfied.
+                         Supported values: warn, error
+EOF
+}
+
 cmd_version() {
   echo "$PROGRAM: $VERSION"
 }
@@ -291,8 +324,188 @@ EOF
 }
 
 # helper functions
+resolve_python_bin() {
+  if [ -n "$SRE_PYTHON_BIN" ]; then
+    if command -v "$SRE_PYTHON_BIN" >/dev/null 2>&1; then
+      command -v "$SRE_PYTHON_BIN"
+      return 0
+    fi
 
-get_latest_local_release() { ls "$SRE_RELEASES_PATH" | sort -r | head -n 1; }
+    if [ -x "$SRE_PYTHON_BIN" ]; then
+      echo "$SRE_PYTHON_BIN"
+      return 0
+    fi
+
+    die "Requested Python interpreter '$SRE_PYTHON_BIN' was not found or is not executable"
+  fi
+
+  for candidate in python3.14 /usr/local/bin/python3.14 /opt/python/3.14/bin/python3.14; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+
+    if [ -x "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  command -v python3 || die "python3 was not found"
+}
+python_version() {
+  "$1" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+}
+
+python_satisfies() {
+  local python_bin="$1"
+  local required_version="$2"
+
+  "$python_bin" - "$required_version" <<'PY'
+import sys
+required = tuple(map(int, sys.argv[1].split(".")[:2]))
+current = sys.version_info[:2]
+sys.exit(0 if current >= required else 1)
+PY
+}
+
+release_metadata_path() {
+  local release="$1"
+  echo "$SRE_RELEASES_PATH/$release/$SRE_RELEASE_METADATA_NAME"
+}
+
+release_metadata_exists() {
+  local release="$1"
+  local metadata_file
+
+  metadata_file="$(release_metadata_path "$release")"
+
+  [ -f "$metadata_file" ]
+}
+
+get_release_metadata_value() {
+  local release="$1"
+  local jq_filter="$2"
+  local metadata_file
+
+  metadata_file="$(release_metadata_path "$release")"
+
+  if [ ! -f "$metadata_file" ]; then
+    return 1
+  fi
+
+  jq -er "$jq_filter" "$metadata_file" 2>/dev/null
+}
+
+get_modular_cli_min_python() {
+  local release="$1"
+
+  if ! release_metadata_exists "$release"; then
+    echo "${SRE_LEGACY_MODULAR_CLI_MIN_PYTHON:-3.10}"
+    return 0
+  fi
+
+  get_release_metadata_value "$release" '.components.modular_cli.python_min_version' \
+    || echo "$SRE_DEFAULT_MODULAR_CLI_MIN_PYTHON"
+}
+
+get_modular_cli_compat_mode() {
+  local release="$1"
+
+  if ! release_metadata_exists "$release"; then
+    echo "${SRE_LEGACY_PYTHON_COMPAT_MODE:-warn}"
+    return 0
+  fi
+
+  get_release_metadata_value "$release" '.components.modular_cli.compatibility_mode' \
+    || echo "$SRE_PYTHON_COMPAT_MODE"
+}
+
+get_modular_cli_breaking_change() {
+  local release="$1"
+
+  if ! release_metadata_exists "$release"; then
+    echo "false"
+    return 0
+  fi
+
+  get_release_metadata_value "$release" '.components.modular_cli.breaking_change' \
+    || echo "false"
+}
+
+get_modular_cli_compat_message() {
+  local release="$1"
+
+  if ! release_metadata_exists "$release"; then
+    echo "Legacy release metadata is missing. Using backward-compatible Python requirements."
+    return 0
+  fi
+
+  get_release_metadata_value "$release" '.components.modular_cli.message' \
+    || echo "Modular CLI requires Python $(get_modular_cli_min_python "$release") or later."
+}
+
+check_modular_cli_python_compatibility() {
+  local release="$1"
+  local python_bin
+  local required_version
+  local current_version
+  local compat_mode
+  local message
+
+  python_bin="$(resolve_python_bin)"
+  required_version="$(get_modular_cli_min_python "$release")"
+  current_version="$(python_version "$python_bin")"
+  compat_mode="$(get_modular_cli_compat_mode "$release")"
+  message="$(get_modular_cli_compat_message "$release")"
+
+  if python_satisfies "$python_bin" "$required_version"; then
+    echo "$python_bin"
+    return 0
+  fi
+
+  cat >&2 <<EOF
+WARNING: Python compatibility change detected.
+
+$message
+
+Required: Python $required_version or later
+Detected: Python $current_version
+Interpreter: $python_bin
+
+To avoid installation or update failures, install Python $required_version+ and explicitly pass it to sre-init:
+
+  SRE_PYTHON_BIN=/usr/local/bin/python${required_version} sre-init init --user <username>
+
+Do not replace the system default /usr/bin/python3, as it may break OS-level tools.
+EOF
+
+  if [ "$compat_mode" = "warn" ]; then
+    echo "$python_bin"
+    return 0
+  fi
+
+  if [ -t 0 ]; then
+    yesno "Continue anyway?"
+    echo "$python_bin"
+    return 0
+  fi
+
+  die "Unsupported Python version for Modular CLI installation"
+}
+
+validate_cli_artifacts() {
+  local release="$1"
+  local release_path="$SRE_RELEASES_PATH/$release"
+
+  [ -f "$release_path/$OBFUSCATOR_ARTIFACT_NAME" ] \
+    || die_with_support "Obfuscator artifact was not found: $release_path/$OBFUSCATOR_ARTIFACT_NAME"
+
+  [ -f "$release_path/$MODULAR_CLI_ARTIFACT_NAME" ] \
+    || die_with_support "Modular CLI artifact was not found: $release_path/$MODULAR_CLI_ARTIFACT_NAME"
+}
+
+get_latest_local_release() { ls "$SRE_RELEASES_PATH" | sort -Vr | head -n 1; }
 get_helm_release_version() {
   # currently the version of rule engine chart corresponds to the version of app inside
   helm get metadata "$1" -o json 2>/dev/null | jq -r '.version'
@@ -471,6 +684,30 @@ build_multiple_params() {
   done
 }
 
+resolve_sre_python() {
+  if [ -n "$SRE_PYTHON_BIN" ]; then
+    command -v "$SRE_PYTHON_BIN" >/dev/null 2>&1 || die "Requested Python interpreter '$SRE_PYTHON_BIN' was not found"
+    "$SRE_PYTHON_BIN" --version >&2
+    echo "$SRE_PYTHON_BIN"
+    return 0
+  fi
+
+  echo "python3"
+}
+pipx_install_artifact() {
+  local python_bin="$1"
+  local app_name="$2"
+  shift 2
+
+  if pipx list | grep -q "package ${app_name} "; then
+    echo "Existing pipx package '${app_name}' found. Removing it before reinstall..."
+    pipx uninstall "$app_name" || true
+  fi
+
+  echo "Installing '${app_name}' using Python interpreter: ${python_bin}"
+  pipx install --force --python "$python_bin" "$@"
+}
+
 initialize_system() {
   # creates:
   # - non-system admin users for Rule Engine & Modular Service
@@ -479,13 +716,21 @@ initialize_system() {
   # - tenant within the customer which represents this AWS account
   # - entity that represents defect dojo installation
   local lm_response customer_name tenant_name modular_service_password rule_engine_password license_key dojo_token="" activation_id
+  local latest_local_release python_bin release_path
 
-  export PATH="$PATH:/home/$FIRST_USER/.local/bin"
+  latest_local_release="$(get_latest_local_release)" || die_with_support "Failed to resolve latest local release"
+
+  validate_cli_artifacts "$latest_local_release"
+
+  python_bin="$(check_modular_cli_python_compatibility "$latest_local_release")"
+  release_path="$SRE_RELEASES_PATH/$latest_local_release"
 
   echo "Installing obfuscation manager"
-  pipx install --force "$SRE_RELEASES_PATH/$(get_latest_local_release)/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" || die_with_support "Failed to install obfuscation manager"
+  pipx_install_artifact "$python_bin" "$release_path/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" "sre-obfuscator" || die_with_support "Failed to install obfuscation manager"
+
   echo "Installing modular-cli"
-  MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx install --force "$SRE_RELEASES_PATH/$(get_latest_local_release)/$MODULAR_CLI_ARTIFACT_NAME" || die_with_support "Failed to install modular-cli"
+  MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT  pipx_install_artifact "$python_bin" "modular-cli" "$release_path/$MODULAR_CLI_ARTIFACT_NAME" || die_with_support "Failed to install modular-cli"
+  export PATH="$PATH:/home/$FIRST_USER/.local/bin"
 
   echo "Logging in to modular-cli"
   syndicate setup --username admin --password "$(get_kubectl_secret modular-api-secret system-password)" --api_path "http://127.0.0.1:8085" --json
@@ -685,10 +930,22 @@ cmd_init() {
     chmod 600 .ssh/authorized_keys
 EOF
   fi
+
+  local latest_local_release python_bin release_path
+
+  latest_local_release="$(get_latest_local_release)" || die_with_support "Failed to resolve latest local release"
+
+  validate_cli_artifacts "$latest_local_release"
+
+  python_bin="$(check_modular_cli_python_compatibility "$latest_local_release")"
+  release_path="$SRE_RELEASES_PATH/$latest_local_release"
+
   echo "Installing CLIs for $target_user"
-  sudo su - "$target_user" <<EOF >/dev/null
-  pipx install --force "$SRE_RELEASES_PATH/$(get_latest_local_release)/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]"
-  MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx install --force "$SRE_RELEASES_PATH/$(get_latest_local_release)/$MODULAR_CLI_ARTIFACT_NAME"
+  sudo su - "$target_user" <<EOF >/dev/null || die_with_support "Failed to install CLIs for user $target_user"
+  pipx uninstall modular-cli || true
+  pipx uninstall sre-obfuscator || true
+  pipx install --force --python "$python_bin" "$release_path/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]"
+  MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx install --force --python "$python_bin" "$release_path/$MODULAR_CLI_ARTIFACT_NAME"
 EOF
 
   local err=0
@@ -1011,16 +1268,20 @@ cmd_update() {
   echo "Going to update to $latest_tag"
   [[ $auto_yes -eq 1 ]] || yesno "Do you want to update?"
   echo "Updating to $latest_tag"
-  if [ "$do_backup" -eq 1 ]; then
-    [ -z "$backup_name" ] && backup_name="$AUTO_BACKUP_PREFIX$(date +%s)"
-    echo "Making backup $backup_name"
-    cmd_backup_create --name "$backup_name" --volumes=minio,mongo,vault
-  fi
   if [ -n "$release_data" ]; then
     echo "Pulling new artifacts"
     # TODO: check artifacts from previous release? and copy if totally the same
     pull_artifacts "$release_data"
   fi
+  if [ -f "$SRE_RELEASES_PATH/$latest_tag/$MODULAR_CLI_ARTIFACT_NAME" ]; then
+    check_modular_cli_python_compatibility "$latest_tag" >/dev/null
+  fi
+  if [ "$do_backup" -eq 1 ]; then
+    [ -z "$backup_name" ] && backup_name="$AUTO_BACKUP_PREFIX$(date +%s)"
+    echo "Making backup $backup_name"
+    cmd_backup_create --name "$backup_name" --volumes=minio,mongo,vault
+  fi
+
   echo "Verifying that necessary helm chart exists"
   helm repo update syndicate || die_with_support "helm repo update failed"
   helm search repo syndicate/rule-engine --version "$latest_tag" --fail-on-no-result >/dev/null 2>&1 || die_with_support "$latest_tag version $HELM_RELEASE_NAME chart not found. Cannot update"
@@ -1038,13 +1299,16 @@ cmd_update() {
     echo "helm upgrade was successful"
   fi
 
+  local cli_python_bin=""
+  cli_python_bin="$(check_modular_cli_python_compatibility "$latest_tag")"
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$OBFUSCATOR_ARTIFACT_NAME" ]; then
     echo "Upgrading obfuscation manager"
-    pipx install --force "$SRE_RELEASES_PATH/$latest_tag/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" >/dev/null
+    pipx_install_artifact "$cli_python_bin" "$SRE_RELEASES_PATH/$latest_tag/${OBFUSCATOR_ARTIFACT_NAME}[xlsx]" "sre-obfuscator" >/dev/null
   fi
+
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$MODULAR_CLI_ARTIFACT_NAME" ]; then
     echo "Upgrading modular CLI"
-    MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx install --force "$SRE_RELEASES_PATH/$latest_tag/${MODULAR_CLI_ARTIFACT_NAME}" >/dev/null
+    MODULAR_CLI_ENTRY_POINT=$MODULAR_CLI_ENTRY_POINT pipx_install_artifact "$cli_python_bin" "$SRE_RELEASES_PATH/$latest_tag/${MODULAR_CLI_ARTIFACT_NAME}" "modular-cli" >/dev/null
   fi
   if [ -f "$SRE_RELEASES_PATH/$latest_tag/$SRE_INIT_ARTIFACT_NAME" ]; then
     echo "Updating sre-init"
@@ -1549,6 +1813,116 @@ cmd_health() {
   done < <(printf "%s\n" "${!checks[@]}" | sort) | column --table -s "|" --table-columns "№,CHECK,STATUS"
 }
 
+cmd_doctor() {
+  local opts release="" latest_local_release="" release_path=""
+  local python_bin="" required_version="" current_version=""
+  local status=0
+
+  opts="$(getopt -o "h" --long "help,release:" -n "$PROGRAM doctor" -- "$@")" \
+    || die "$(cmd_unrecognized)"
+
+  eval set -- "$opts"
+
+  while true; do
+    case "$1" in
+      -h | --help)
+        cmd_doctor_usage
+        exit 0
+        ;;
+      --release)
+        release="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        die "$(cmd_unrecognized)"
+        ;;
+    esac
+  done
+
+  if [ -n "$release" ]; then
+    latest_local_release="$release"
+  else
+    latest_local_release="$(get_latest_local_release 2>/dev/null || true)"
+  fi
+
+  echo "SRE init environment check"
+  echo
+
+  if command -v pipx >/dev/null 2>&1; then
+    echo "[OK] pipx found: $(command -v pipx)"
+  else
+    echo "[ERROR] pipx was not found"
+    status=1
+  fi
+
+  if [ -n "$latest_local_release" ]; then
+    release_path="$SRE_RELEASES_PATH/$latest_local_release"
+    echo "[OK] Local release resolved: $latest_local_release"
+
+    if release_metadata_exists "$latest_local_release"; then
+      echo "[OK] Release metadata found: $(release_metadata_path "$latest_local_release")"
+    else
+      echo "[WARN] Release metadata not found. Treating release as legacy."
+    fi
+
+    if [ -d "$release_path" ]; then
+      echo "[OK] Release directory found: $release_path"
+    else
+      echo "[ERROR] Release directory was not found: $release_path"
+      status=1
+    fi
+
+    if [ -f "$release_path/$MODULAR_CLI_ARTIFACT_NAME" ]; then
+      echo "[OK] Modular CLI artifact found"
+    else
+      echo "[ERROR] Modular CLI artifact not found: $release_path/$MODULAR_CLI_ARTIFACT_NAME"
+      status=1
+    fi
+
+    if [ -f "$release_path/$OBFUSCATOR_ARTIFACT_NAME" ]; then
+      echo "[OK] Obfuscator artifact found"
+    else
+      echo "[ERROR] Obfuscator artifact not found: $release_path/$OBFUSCATOR_ARTIFACT_NAME"
+      status=1
+    fi
+
+    required_version="$(get_modular_cli_min_python "$latest_local_release")"
+    echo "[INFO] Modular CLI Python requirement: >=$required_version"
+  else
+    echo "[WARN] Could not resolve latest local release from $SRE_RELEASES_PATH"
+    required_version="$SRE_DEFAULT_MODULAR_CLI_MIN_PYTHON"
+    status=1
+  fi
+
+  python_bin="$(resolve_python_bin 2>/dev/null || true)"
+
+  if [ -n "$python_bin" ]; then
+    current_version="$(python_version "$python_bin")"
+
+    echo "[INFO] Resolved Python interpreter: $python_bin"
+    echo "[INFO] Resolved Python version: $current_version"
+
+    if python_satisfies "$python_bin" "$required_version"; then
+      echo "[OK] Python requirement satisfied"
+    else
+      echo "[WARN] Python requirement is not satisfied"
+      echo
+      echo "Recommended command:"
+      echo "  SRE_PYTHON_BIN=/usr/local/bin/python${required_version} $PROGRAM init --user <username>"
+      status=1
+    fi
+  else
+    echo "[ERROR] Could not resolve Python interpreter"
+    status=1
+  fi
+
+  return "$status"
+}
+
 verify_installation() {
   if [ -f "$SRE_LOCAL_PATH/.success" ]; then
     return 0
@@ -1569,13 +1943,22 @@ verify_installation() {
 }
 
 # Start
-VERSION="1.2.1"
+VERSION="1.3.0"
 PROGRAM="${0##*/}"
 COMMAND="$1"
 SELF_PATH=/usr/local/bin/sre-init # TODO: resolve dynamically?
 readonly _ORIGINAL_ARGS=("$@")
 
 # Some variables that configure how cli behaves
+SRE_PYTHON_BIN="${SRE_PYTHON_BIN:-}"
+SRE_RELEASE_METADATA_NAME="${SRE_RELEASE_METADATA_NAME:-release.json}"
+# Defaults for new releases when release.json exists but some fields are missing
+SRE_DEFAULT_MODULAR_CLI_MIN_PYTHON="${SRE_DEFAULT_MODULAR_CLI_MIN_PYTHON:-3.14}"
+SRE_PYTHON_COMPAT_MODE="${SRE_PYTHON_COMPAT_MODE:-error}"
+# Defaults for old releases without release.json
+SRE_LEGACY_MODULAR_CLI_MIN_PYTHON="${SRE_LEGACY_MODULAR_CLI_MIN_PYTHON:-3.10}"
+SRE_LEGACY_PYTHON_COMPAT_MODE="${SRE_LEGACY_PYTHON_COMPAT_MODE:-warn}"
+
 AUTO_BACKUP_PREFIX="${AUTO_BACKUP_PREFIX:-autobackup-}"
 SRE_LOCAL_PATH="${SRE_LOCAL_PATH:-/usr/local/sre}"
 SRE_RELEASES_PATH="${SRE_RELEASES_PATH:-$SRE_LOCAL_PATH/releases}"
@@ -1702,6 +2085,14 @@ case "$1" in
   health)
     shift
     cmd_health "$@"
+    ;;
+  doctor)
+    shift
+    cmd_doctor "$@"
+    ;;
+  check)
+    shift
+    cmd_doctor "$@"
     ;;
   --system | --user) cmd_init "$@" ;; # redirect to init as default one
   '') cmd_usage ;;

--- a/deployment/aws-ami/debian-minikube/sre-init.sh
+++ b/deployment/aws-ami/debian-minikube/sre-init.sh
@@ -1078,23 +1078,37 @@ warn_if_update_available() {
     warn "new $(get_release_type "$release_data") $(jq -r '.tag_name' <<<"$release_data") is available. Use 'sre-init update'"
   fi
 }
+_write_update_notification() {
+  echo "$UPDATE_NOTIFICATION_PERIOD:$(($(date +%s) / UPDATE_NOTIFICATION_PERIOD))" >"$UPDATE_NOTIFICATION_FILE"
+}
+
+_reset_update_notification() {
+  rm -f "$UPDATE_NOTIFICATION_FILE"
+  warn_if_update_available || return 1
+  _write_update_notification
+}
 make_update_notification() {
   if [ ! -f "$UPDATE_NOTIFICATION_FILE" ]; then
-    warn_if_update_available || return 1
-    echo "$UPDATE_NOTIFICATION_PERIOD:$(($(date +%s) / UPDATE_NOTIFICATION_PERIOD))" >"$UPDATE_NOTIFICATION_FILE"
+    _reset_update_notification
     return
   fi
-  # file exists
-  local period passed
-  IFS=':' read -r period passed <"$UPDATE_NOTIFICATION_FILE"
-  if [ -z "$period" ] || [ "$period" -eq 0 ] 2>/dev/null; then
-    rm -f "$UPDATE_NOTIFICATION_FILE"
-    return 0
-  fi
-  if [ "$(($(date +%s) / period))" -ne "$passed" ]; then
-    warn_if_update_available || return 1
-    echo "$UPDATE_NOTIFICATION_PERIOD:$(($(date +%s) / UPDATE_NOTIFICATION_PERIOD))" >"$UPDATE_NOTIFICATION_FILE"
+
+  local period passed current_bucket
+  IFS=':' read -r period passed <"$UPDATE_NOTIFICATION_FILE" || {
+    _reset_update_notification  # I/O error
     return
+  }
+
+  if ! [[ "$period" =~ ^[1-9][0-9]*$ ]]; then
+    _reset_update_notification  # invalid data
+    return
+  fi
+
+  current_bucket=$(($(date +%s) / period))
+  if [ "$current_bucket" -ne "$passed" ]; then
+    # File valid, just new time interval — check and overwrite
+    warn_if_update_available || return 1
+    _write_update_notification
   fi
 }
 

--- a/deployment/aws-ami/docs/upgrade.md
+++ b/deployment/aws-ami/docs/upgrade.md
@@ -1,59 +1,128 @@
 # Update Guide
 
-The flow of product update is fully automated.
+The update process is fully automated. EPAM Syndicate Rule Engine uses an **incremental upgrade flow** — it is only possible to update through each successive version; skipping intermediate versions is not supported.
 
-EPAM Syndicate Rule Engine implements the incremental upgrades flow - it's only
-possible to update software through each successive version without skipping any intermediate versions.
+All commands must be executed **directly on the SRE AMI instance** via SSH.
 
-Please follow the following step to update the product:
+---
 
-### 1. Connect to instance via SSH:
-Connect to the product instance using the SSH key using this command: 
-`ssh -i $SSH_KEY_NAME admin@$INSTANCE_PUBLIC_DNS` where:
-   - `$SSH_KEY_NAME` is the actual name of the key file;
-   - `$INSTANCE_PUBLIC_DNS` is the actual public DNS of the instance.
+### 1. Connect to the instance via SSH
 
-### 2. List releases
-Once log in to instance, please execute the following command in order to list all the releases available starting from the current version:
+```bash
+ssh -i $SSH_KEY_NAME admin@$INSTANCE_PUBLIC_DNS
+```
 
-`sre-init list`
+- `$SSH_KEY_NAME` — the name of your SSH key file
+- `$INSTANCE_PUBLIC_DNS` — the public DNS of the instance
 
-Here is the command output sample: 
+---
 
-| Version | Release Date         | URL                                                                                                                                  | Prerelease | Draft |
-|---------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------|------------|-------|
-| 5.5.1   | NEW RELEASE DATE     | [NEW RELEASE LINK](https://github.com/epam/syndicate-rule-engine/releases/tag/5.5.0)                                                 | false      | false |
-| 5.5.0*  | 2024-10-16T09:01:13Z | [https://github.com/epam/syndicate-rule-engine/releases/tag/5.5.0](https://github.com/epam/syndicate-rule-engine/releases/tag/5.5.0) | false      | false |
+### 2. List available releases
 
-The installed version is marked with asteriks `*` nearby the version number: `5.5.0*`.
+Run the following command to see all releases available from the currently installed version:
 
-This command is integrated with [GitHub releases of the product](https://github.com/epam/syndicate-rule-engine/releases).
+```bash
+sre-init list
+```
 
-### 3. Check if update available
-To check if new release is available please execute the following command:
+Expected output:
 
-`sre-init update --check`
+| Version | Release Date         | URL                                                                 | Prerelease | Draft |
+|---------|----------------------|---------------------------------------------------------------------|------------|-------|
+| 5.5.1   | 2024-11-01T10:00:00Z | https://github.com/epam/syndicate-rule-engine/releases/tag/5.5.1   | false      | false |
+| 5.5.0*  | 2024-10-16T09:01:13Z | https://github.com/epam/syndicate-rule-engine/releases/tag/5.5.0   | false      | false |
 
-The command will return the `Up-to-date` response with the `0` status code if update is not available and `1` status code 
-otherwise - this may be useful for any automation build atop of `sre-init` tool. 
+The currently installed version is marked with an asterisk `*`.
 
-### 4. Syndicate Rule Engine Update
-To initiate the update to the next version please execute the following command:
+---
 
-`sre-init update --yes`
+### 3. Check whether an update is available
 
-**Note:** no prompt will be shown if you specify `--yes` flag.
+```bash
+sre-init update --check
+```
 
-The command produces logs to console notifying the user about the update progress.  
-> The command is fail-safe. The 'sre-init' tool will rollback all the changes made to the software in case of failure.
-> 
-> This allows to return the product to the previous state. 
+- Returns `Up-to-date` with exit code `0` if no update is available.
+- Returns exit code `1` if a new release is found — useful for automation.
 
-In case update successfully ended - the following message will be diplayed: `Done`;
+---
 
-### 5. Defect Dojo Update
+### 4. Refresh the update manager
 
-To update Defect Dojo use:
+Before performing the upgrade, ensure `sre-init` itself is up to date:
+
+```bash
+sre-init update --same-version --no-backup --no-patch
+```
+
+Expected output:
+
+```
+Automatically updated sre-init from <current_version> to <new_version>
+```
+
+---
+
+### 5. Perform the update
+
+```bash
+sre-init update
+```
+
+When prompted, confirm by typing `y`:
+
+```
+Do you want to update? [y/N] y
+```
+
+> Use `sre-init update --yes` to skip the confirmation prompt.
+
+The command logs progress to the console. Expected output upon successful completion:
+
+```
+The current installed version is <previous_version>
+New github release <new_version> is available
+Going to update to <new_version>
+Pulling new artifacts
+Verifying that necessary helm chart exists
+Making helm upgrade. It should not take more than 20 minutes
+helm upgrade was successful
+Upgrading obfuscation manager
+Upgrading modular CLI
+Updating sre-init
+Done
+```
+
+> **Note:** The helm upgrade step may take up to 20 minutes. Do not interrupt the process.  
+> The update is fail-safe — if anything goes wrong, `sre-init` will automatically roll back all changes to the previous state.
+
+---
+
+### 6. Verify the installation health
+
+After the update completes, confirm all components are running correctly:
+
+```bash
+sre-init health
+```
+
+Expected output — all checks should show `ok`:
+
+```
+№  CHECK                               STATUS
+1  /usr/local/sre/.success             ok
+2  Syndicate Rule Engine helm release  ok
+3  Syndicate entrypoint                ok
+4  Syndicate Rule Engine health check  ok
+5  Obfuscation manager entrypoint      ok
+6  Defect Dojo helm release            ok
+```
+
+---
+
+### 7. Defect Dojo update (optional)
+
+To update Defect Dojo separately:
 
 ```bash
 sre-init update --defectdojo
@@ -61,6 +130,14 @@ sre-init update --defectdojo
 
 > This update is fail-safe as well.
 
+---
 
-### Support
-In case of any issues please contact [SupportSyndicateTeam@epam.com](mailto:SupportSyndicateTeam@epam.com)
+### Troubleshooting
+
+If the update fails or any health check reports `failed`, collect the log file from the instance and contact our support team:
+
+```bash
+scp -i $SSH_KEY_NAME admin@$INSTANCE_PUBLIC_DNS:/var/log/sre-init.log /your/local/directory/
+```
+
+Contact: [SupportSyndicateTeam@epam.com](mailto:SupportSyndicateTeam@epam.com)

--- a/deployment/helm/defectdojo/Chart.yaml
+++ b/deployment/helm/defectdojo/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.34.2"
 description: A Helm chart for defectdojo
 name: defectdojo
 type: application
-version: "1.1.0"
+version: "1.1.1"

--- a/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
@@ -24,7 +24,11 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-celery-beat.sh"]
+        - command:
+            - "/bin/sh"
+            - "-c"
+            - >-
+              ulimit -n 65536 && exec /wait-for-it.sh {{ include "defectdojo.fullname" . }}-postgres:5432 -t 30 -- /entrypoint-celery-beat.sh
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/wait-for-it.sh", '{{ include "defectdojo.fullname" . }}-postgres:5432', "-t", "30", "--", "/entrypoint-celery-beat.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-celery-beat.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celerybeat-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-celery-beat.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-celery-beat.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
@@ -24,7 +24,11 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-celery-worker.sh"]
+        - command:
+            - "/bin/sh"
+            - "-c"
+            - >-
+              ulimit -n 65536 && exec /wait-for-it.sh {{ include "defectdojo.fullname" . }}-postgres:5432 -t 30 -- /entrypoint-celery-worker.sh
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-celery-worker.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-celery-worker.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/celeryworker-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/wait-for-it.sh", '{{ include "defectdojo.fullname" . }}-postgres:5432', "-t", "30", "--", "/entrypoint-celery-worker.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-celery-worker.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
@@ -24,7 +24,11 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-uwsgi.sh"]
+        - command:
+            - "/bin/sh"
+            - "-c"
+            - >-
+              ulimit -n 65536 && exec /wait-for-it.sh {{ include "defectdojo.fullname" . }}-postgres:5432 -t 30 -- /entrypoint-uwsgi.sh
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/wait-for-it.sh", '{{ include "defectdojo.fullname" . }}-postgres:5432', "-t", "30", "--", "/entrypoint-uwsgi.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-uwsgi.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
+++ b/deployment/helm/defectdojo/templates/uwsgi-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         helm.sh/chart: {{ include "defectdojo.chart" . }}
     spec:
       containers:
-        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include \"defectdojo.fullname\" . }}-postgres:5432 -t 30 -- /entrypoint-uwsgi.sh"]
+        - command: ["/bin/sh", "-c", "ulimit -n 65536 && exec /wait-for-it.sh {{ include 'defectdojo.fullname' . }}-postgres:5432 -t 30 -- /entrypoint-uwsgi.sh"]
           resources:
             requests:
               memory: "128Mi"

--- a/deployment/helm/rule-engine/Chart.yaml
+++ b/deployment/helm/rule-engine/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
     condition: redis.enabled
   - name: modular-service
     repository: "s3://charts-repository/syndicate/"
-    version: "3.3.2"
+    version: "3.4.0"
     condition: modular-service.enabled
   - name: modular-api
     repository: "s3://charts-repository/syndicate/"

--- a/deployment/helm/rule-engine/values.yaml
+++ b/deployment/helm/rule-engine/values.yaml
@@ -12,7 +12,7 @@ service:
 
 image:
   repository: public.ecr.aws/x4s4z8e1/syndicate/rule-engine
-  tag: 5.20.0-beta4
+  tag: 5.20.0
   pullPolicy: Always
 
 replicas: 1
@@ -62,7 +62,7 @@ modular-api:
   modularApiM3adminLogLevel: ERROR
   modularApiModularSdkLogLevel: ERROR
   image:
-    tag: 4.4.0-rule-engine-5.20.0-beta3
+    tag: 4.4.0-rule-engine-5.20.0
 
 patch:
   enabled: false

--- a/deployment/helm/rule-engine/values.yaml
+++ b/deployment/helm/rule-engine/values.yaml
@@ -12,7 +12,7 @@ service:
 
 image:
   repository: public.ecr.aws/x4s4z8e1/syndicate/rule-engine
-  tag: 5.20.0
+  tag: 5.20.0-beta4
   pullPolicy: Always
 
 replicas: 1
@@ -62,7 +62,7 @@ modular-api:
   modularApiM3adminLogLevel: ERROR
   modularApiModularSdkLogLevel: ERROR
   image:
-    tag: 4.3.26-rule-engine-5.14.0
+    tag: 4.4.0-rule-engine-5.20.0-beta3
 
 patch:
   enabled: false


### PR DESCRIPTION
- Fixed artifact resolution in get_latest_local_release during user addition.
- Improved local release artifact detection to ensure the correct SRE artifacts are selected when installing CLI tools for a user.
- Added support for explicitly specifying the Python interpreter used during CLI installation.
- This change prepares the installation flow for future Modular CLI requirements, where Modular CLI will support only Python 3.14 and later versions.
- Added Python version validation before Modular CLI installation/update.
- Added support for reading Modular CLI Python requirements from release metadata.
- Added a doctor / check command to validate local environment readiness.
- Added user-facing warnings/errors for Python compatibility changes.
- Avoided changing or relying on the system default /usr/bin/python3.
- Resolved the latest local release only once during CLI installation to avoid inconsistent artifact resolution during user initialization.