### PR TITLE
minor fixes in cli

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sre report resource job`
   - `sre report rules jobs`
 
+### Fixed
+- Fixed hint for `sre rule update` command if a caller is system user
+
 ## [5.20.0] - 2026-07-29
 
 ### Added

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,7 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sre report rules jobs`
 
 ### Fixed
-- Fixed hint for `sre rule update` command if a caller is system user
+- Fixed hint for `sre rule update` command if the caller is a system user
+- Fixed a typo in the help message for `--username` option in user-related commands:
+  - `sre users update`
+  - `sre users delete`
 
 ## [5.20.0] - 2026-07-29
 

--- a/cli/srecli/group/rule.py
+++ b/cli/srecli/group/rule.py
@@ -26,7 +26,10 @@ def _add_rule_source_hints(resp: SREResponse, customer_id: str) -> None:
                 status = item.get(STATUS_ATTR, '')
                 if 'currently being updated' in status:
                     continue
-                item[STATUS_ATTR] = f"""To check: 'sre rulesource describe -rsid {rule_source_id} -cid "{customer_id}"'"""
+                cmd = f'sre rulesource describe -rsid {rule_source_id}'
+                if customer_id:
+                    cmd += f' -cid "{customer_id}"'
+                item[STATUS_ATTR] = f"To check: '{cmd}'"
         resp.data = data
 
 

--- a/cli/srecli/group/users.py
+++ b/cli/srecli/group/users.py
@@ -52,7 +52,7 @@ def create(ctx: ContextObj, username, password, role_name, customer_id):
 
 @users.command(cls=ViewCommand, name='update')
 @click.option('--username', required=True, type=str,
-              help='Username to create user')
+              help='Username to update user')
 @click.option('--password', '-p', type=str, help='New user password')
 @click.option('--role_name', '-rn', type=str,
               help='Role to assign to this user. '
@@ -72,7 +72,7 @@ def update(ctx: ContextObj, username, customer_id, password, role_name):
 
 @users.command(cls=ViewCommand, name='delete')
 @click.option('--username', required=True, type=str,
-              help='Username to create user')
+              help='Username to delete user')
 @cli_response()
 def delete(ctx: ContextObj, username, customer_id):
     """


### PR DESCRIPTION
- Fixed hint for `sre rule update` command if the caller is a system user
- Fixed a typo in the help message for `--username` option in user-related commands:
  - `sre users update`
  - `sre users delete`